### PR TITLE
Change Quartz's Console to Serpo's Console

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ and should maintain full compatibility.
 <summary>Not your cup of tea?</summary>
 Thats okay! Consider trying <a href="https://modrinth.com/modpack/legacy_console_experience">Legacy Console Experience</a> from MonFloMat 
 
-Or trying <a href="https://modrinth.com/modpack/quartzs-console-rewritten">Quartz's Console</a> from QuartzMaven
+Or trying <a href="https://modrinth.com/modpack/serpos-console">Serpo's Console</a> from serpo, omoso and Quartzmaven
 <p>LEM compatibility not guaranteed</p>
 
 <details open>


### PR DESCRIPTION
As of March 20th 2024, Quartz's Console was deprecated in favor of my project Serpo's Console
I see no point to leave a dead project linked, and this project is a direct continuation