### PR TITLE
Remove Serpo's Console link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,6 @@ and should maintain full compatibility.
 <summary>Not your cup of tea?</summary>
 Thats okay! Consider trying <a href="https://modrinth.com/modpack/legacy_console_experience">Legacy Console Experience</a> from MonFloMat 
 
-Or trying <a href="https://modrinth.com/modpack/serpos-console">Serpo's Console</a> from serpo, omoso and Quartzmaven
-<p>LEM compatibility not guaranteed</p>
-
 <details open>
 <summary>Better Legacy Emulation</summary>
 Consider trying <a href="https://modrinth.com/mod/legacy-minecraft">Legacy4J</a>

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ and should maintain full compatibility.
 
 <details open>
 <summary>Not your cup of tea?</summary>
-Thats okay! Consider trying <a href="https://modrinth.com/modpack/legacy_console_experience">Legacy Console Experience</a> from MonFloMat
+That's okay! Maybe try [Re-Console](https://modrinth.com/modpack/legacy-minecraft) from omoso, Wilyicaro and more
+
+Or try <a href="https://modrinth.com/modpack/legacy_console_experience">Legacy Console Experience</a> from MonFloMat
 
 <p>LEM compatibility not guaranteed</p>
 <details open>


### PR DESCRIPTION
Serpo's Console has been deprecated in favor of the upcoming Legacy4J official modpack (also worked on by me)

this just removes the link and mention of Serpo's Console
If you'd be interested in helping with the official modpack, or want to know more about it, send me a friend request on discord (@omo50) or join the Legacy4J discord and we can discuss